### PR TITLE
[Fix Bug] fix small bug in test_multiagent.py

### DIFF
--- a/experiments/learning/test_multiagent.py
+++ b/experiments/learning/test_multiagent.py
@@ -319,7 +319,9 @@ if __name__ == "__main__":
         temp = {}
         temp[0] = policy0.compute_single_action(np.hstack([action[1], obs[1], obs[0]])) # Counterintuitive order, check params.json
         temp[1] = policy1.compute_single_action(np.hstack([action[0], obs[0], obs[1]]))
-        action = {0: temp[0][0], 1: temp[1][0]}
+        action = {0: temp[0][0]}
+        for i in range(1, NUM_DRONES):
+            action[i] = temp[1][0]
         obs, reward, done, info = test_env.step(action)
         test_env.render()
         if OBS==ObservationType.KIN: 


### PR DESCRIPTION
- Change actions that passed to env.step() to include actions for all agents

## Previously

There are only 2 policies in experiments/learning/multiagent.py to be trained

https://github.com/utiasDSL/gym-pybullet-drones/blob/333ec90219bd39fe69aad53734a21f27faf2449b/experiments/learning/multiagent.py#L269-L273

There are only 2 policies imported from the trained agent and the dictionary that is passed for env.step stores actions only for 2 drones.

https://github.com/utiasDSL/gym-pybullet-drones/blob/333ec90219bd39fe69aad53734a21f27faf2449b/experiments/learning/test_multiagent.py#L265-L271

https://github.com/utiasDSL/gym-pybullet-drones/blob/333ec90219bd39fe69aad53734a21f27faf2449b/experiments/learning/test_multiagent.py#L319-L323

## Now

The same 2 policies imported and only the actions are passed for all the agents.

https://github.com/hany606/gym-pybullet-drones/blob/fe1b1a47eb451f0d6b972bb2eb7c8e09fafb66df/experiments/learning/test_multiagent.py#L319-L325

## Next
This fix works perfect for leader and follower environment but not on other environments I believe, as we have multiple agents and each agent can have a different policy, but I am not sure if it was an intention only to implement it like this or not. Thus, in another pull-request or a continuation for this pull-request, I can change the implementation of experiments/learning/multiagent.py to train a policy for each agent.

At the end, thank you very much for your simulator, it is great and really amazing documentation!