### PR TITLE
Make PyBullet use the inertia tensor provided in the URDF file

### DIFF
--- a/gym_pybullet_drones/envs/BaseAviary.py
+++ b/gym_pybullet_drones/envs/BaseAviary.py
@@ -485,6 +485,7 @@ class BaseAviary(gym.Env):
         self.DRONE_IDS = np.array([p.loadURDF(os.path.dirname(os.path.abspath(__file__))+"/../assets/"+self.URDF,
                                               self.INIT_XYZS[i,:],
                                               p.getQuaternionFromEuler(self.INIT_RPYS[i,:]),
+                                              flags = p.URDF_USE_INERTIA_FROM_FILE,
                                               physicsClientId=self.CLIENT
                                               ) for i in range(self.NUM_DRONES)])
         for i in range(self.NUM_DRONES):


### PR DESCRIPTION
By default, when providing a URDF file to PyBullet via `loadURDF`, Bullet recomputes the inertia tensor based on mass and volume of the collision shape (see the official [documentation](https://docs.google.com/document/d/10sXEhzFRSnvFcl3XxNGhnD4N2SedqwdAvK3dsihxVUA) on page 8/9). As you are well aware, this is problematic in the case of drones as the collision shape is usually a cylinder or ellipsoid to accommodate for downwash effects.  

To give an example, when adding the following lines to _examples/fly.py_,
```   
#### Obtain the PyBullet Client ID from the environment ####
PYB_CLIENT = env.getPyBulletClient()
    
for i in env.DRONE_IDS:
      print("The intertia tensor of drone ", i, "is ", p.getDynamicsInfo(i, -1)[2])
```
, the output is 
``` 
The intertia tensor of drone  1 is  (3.788324848467e-05, 3.788324848467e-05, 7.144199714232e-05)
The intertia tensor of drone  2 is  (3.788324848467e-05, 3.788324848467e-05, 7.144199714232e-05)
The intertia tensor of drone  3 is  (3.788324848467e-05, 3.788324848467e-05, 7.144199714232e-05)
``` 
With the proposed change the output becomes
``` 
The intertia tensor of drone  1 is  (1.4e-05, 1.4e-05, 2.17e-05)
The intertia tensor of drone  2 is  (1.4e-05, 1.4e-05, 2.17e-05)
The intertia tensor of drone  3 is  (1.4e-05, 1.4e-05, 2.17e-05)
``` 
, which matches the specification in _assets/cf2x.urdf_. The impact on the simulation is noticeable and, overall, seems more reasonable:

Before             |  After
:-------------------------:|:-------------------------:
![fly_before](https://user-images.githubusercontent.com/35602050/129245981-9ecdc73e-6fc5-443a-88e3-f795a098018e.png)  |  ![fly_after](https://user-images.githubusercontent.com/35602050/129245976-b4eb259e-458b-4050-8754-23832b74bc12.png)