### PR TITLE
Fix a small bug in BaseMultiagentAviary.py

### DIFF
--- a/gym_pybullet_drones/envs/multi_agent_rl/BaseMultiagentAviary.py
+++ b/gym_pybullet_drones/envs/multi_agent_rl/BaseMultiagentAviary.py
@@ -9,6 +9,7 @@ from gym_pybullet_drones.envs.single_agent_rl.BaseSingleAgentAviary import Actio
 from gym_pybullet_drones.utils.utils import nnlsRPM
 from gym_pybullet_drones.control.DSLPIDControl import DSLPIDControl
 from gym_pybullet_drones.control.SimplePIDControl import SimplePIDControl
+import pybullet as p
 
 class BaseMultiagentAviary(BaseAviary, MultiAgentEnv):
     """Base multi-agent environment class for reinforcement learning."""


### PR DESCRIPTION
## Description

When ```obs=ObservationType.RGB``` then the obstacles will be added to the environment, however, there will be an error ```NameError: name 'p' is not defined```.
This happens when someone creates a new class inherit from BaseMultiagentAviary and then use ObservationType.RGB for the observations

## Solution

Thus, we need just to ```import pybullet as p``` at the top of the file

Please, let me know if I am missing something, thank you in advance!