### PR TITLE
getpass.getuser() instead of os.getlogin() for Ubuntu/ROS2

### DIFF
--- a/ros2/src/ros2_gym_pybullet_drones/ros2_gym_pybullet_drones/aviary_wrapper.py
+++ b/ros2/src/ros2_gym_pybullet_drones/ros2_gym_pybullet_drones/aviary_wrapper.py
@@ -4,9 +4,12 @@ It creates an environment CtrlAviary and continually calls CtrlAviary.step().
 It publishes on topic 'obs' and reads from topic 'action'.
 """
 import sys, os  # See: https://github.com/utiasDSL/gym-pybullet-drones/issues/89
+import getpass
 sys.path.append(sys.path[0].replace("ros2/install/ros2_gym_pybullet_drones/lib/ros2_gym_pybullet_drones", ""))
-sys.path.append("/Users/"+os.getlogin()+"/opt/anaconda3/envs/drones/lib/python3.8/site-packages")  # macOS
-# sys.path.append("/home/"+os.getlogin()+"/anaconda3/envs/drones/lib/python3.8/site-packages")  # Ubuntu
+if sys.platform == 'darwin': # macOS
+    sys.path.append("/Users/"+os.getlogin()+"/opt/anaconda3/envs/drones/lib/python3.8/site-packages")  
+elif sys.platform == 'linux': # Ubuntu
+    sys.path.append("/home/"+getpass.getuser()+"/anaconda3/envs/drones/lib/python3.8/site-packages")  
 
 import rclpy
 import numpy as np

--- a/ros2/src/ros2_gym_pybullet_drones/ros2_gym_pybullet_drones/random_control.py
+++ b/ros2/src/ros2_gym_pybullet_drones/ros2_gym_pybullet_drones/random_control.py
@@ -4,9 +4,12 @@ It subscribes to aviary_wrapper's 'obs' topic (but ignores it).
 It publishes random RPMs on topic 'action'.
 """
 import sys, os  # See: https://github.com/utiasDSL/gym-pybullet-drones/issues/89
+import getpass
 sys.path.append(sys.path[0].replace("ros2/install/ros2_gym_pybullet_drones/lib/ros2_gym_pybullet_drones", ""))
-sys.path.append("/Users/"+os.getlogin()+"/opt/anaconda3/envs/drones/lib/python3.8/site-packages")  # macOS
-# sys.path.append("/home/"+os.getlogin()+"/anaconda3/envs/drones/lib/python3.8/site-packages")  # Ubuntu
+if sys.platform == 'darwin': # macOS
+    sys.path.append("/Users/"+os.getlogin()+"/opt/anaconda3/envs/drones/lib/python3.8/site-packages")  
+elif sys.platform == 'linux': # Ubuntu
+    sys.path.append("/home/"+getpass.getuser()+"/anaconda3/envs/drones/lib/python3.8/site-packages")  
 
 import rclpy
 import random


### PR DESCRIPTION
- When running ROS2 wrappers on Ubuntu, we encountered the below error:
```bash
File "/home/ben/gym-pybullet-drones/ros2/build/ros2_gym_pybullet_drones/ros2_gym_pybullet_drones/aviary_wrapper.py", line 9, in <module>
sys.path.append("/home/"+os.getlogin()+"/anaconda3/envs/drones/lib/python3.8/site-packages")  # Ubuntu
FileNotFoundError: [Errno 2] No such file or directory
```
It's solved by using ```getpass.getuser()``` in the [getpass](https://docs.python.org/3/library/getpass.html#module-getpass) module.

- Also, by default, we should have manually commented out the following part depending on our OS:
```bash
sys.path.append("/Users/"+os.getlogin()+"/opt/anaconda3/envs/drones/lib/python3.8/site-packages")  # macOS
# sys.path.append("/home/"+os.getlogin()+"/anaconda3/envs/drones/lib/python3.8/site-packages")  # Ubuntu
```
However, this issue's automated by using ```sys.platform```.
