### PR TITLE
Gym v26 Migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# gym-pybullet-drones
+# gym-pybullet-drones (v26 migration)
 
 [Simple](https://en.wikipedia.org/wiki/KISS_principle) OpenAI [Gym environment](https://gym.openai.com/envs/#classic_control) based on [PyBullet](https://github.com/bulletphysics/bullet3) for multi-agent reinforcement learning with quadrotors
 

--- a/gym_pybullet_drones/envs/BaseAviary.py
+++ b/gym_pybullet_drones/envs/BaseAviary.py
@@ -230,6 +230,11 @@ class BaseAviary(gym.Env):
         ndarray | dict[..]
             The initial observation, check the specific implementation of `_computeObs()`
             in each subclass for its format.
+            
+        TODO UPDATE TO GYM v26
+            reset() further returns info, similar to the info returned by step().
+            This is important because info can include metrics or valid action mask
+            that is used or saved in the next step.
 
         """
         p.resetSimulation(physicsClientId=self.CLIENT)
@@ -269,6 +274,10 @@ class BaseAviary(gym.Env):
         dict[..]
             Additional information as a dictionary, check the specific implementation of `_computeInfo()`
             in each subclass for its format.
+            
+        TODO UPDATE TO GYM v26
+            For users wishing to update, in most cases, replacing done with terminated and truncated=False 
+            in step() should address most issues.
 
         """
         #### Save PNG video frames if RECORD=True and GUI=False ####


### PR DESCRIPTION
As per [this link](https://gymnasium.farama.org/content/migration-guide/) and requested in #133:

This PR will include changes migrating/supporting from **v21**

```python
import gym
env = gym.make("LunarLander-v2", options={})
env.seed(123)
observation = env.reset()

done = False
while not done:
    action = env.action_space.sample()  # agent policy that uses the observation and info
    observation, reward, done, info = env.step(action)

    env.render(mode="human")

env.close()
```

to **v26**

```python
import gym
env = gym.make("LunarLander-v2", render_mode="human")
observation, info = env.reset(seed=123, options={})

done = False
while not done:
    action = env.action_space.sample()  # agent policy that uses the observation and info
    observation, reward, terminated, truncated, info = env.step(action)

    done = terminated or truncated

env.close()
```

