### PR TITLE
change step and reset function for ray2.3

### DIFF
--- a/gym_pybullet_drones/envs/BaseAviary.py
+++ b/gym_pybullet_drones/envs/BaseAviary.py
@@ -240,7 +240,8 @@ class BaseAviary(gym.Env):
         #### Start video recording #################################
         self._startVideoRecording()
         #### Return the initial observation ########################
-        return self._computeObs()
+        #return self._computeObs() #ray2.2
+        return self._computeObs(), {} #ray2.3
     
     ################################################################################
 
@@ -354,7 +355,11 @@ class BaseAviary(gym.Env):
         info = self._computeInfo()
         #### Advance the step counter ##############################
         self.step_counter = self.step_counter + (1 * self.AGGR_PHY_STEPS)
-        return obs, reward, done, info
+        #return obs, reward, done, info #ray2.2
+        terminated = done #ray2.3
+        truncated = False #ray2.3
+        return obs, reward, terminated, truncated, info #ray2.3
+    
     
     ################################################################################
     

--- a/gym_pybullet_drones/envs/BaseAviary.py
+++ b/gym_pybullet_drones/envs/BaseAviary.py
@@ -240,7 +240,7 @@ class BaseAviary(gym.Env):
         #### Start video recording #################################
         self._startVideoRecording()
         #### Return the initial observation ########################
-        #return self._computeObs() #ray2.2
+        #return self._computeObs() #ray1.9
         return self._computeObs(), {} #ray2.3
     
     ################################################################################
@@ -355,7 +355,7 @@ class BaseAviary(gym.Env):
         info = self._computeInfo()
         #### Advance the step counter ##############################
         self.step_counter = self.step_counter + (1 * self.AGGR_PHY_STEPS)
-        #return obs, reward, done, info #ray2.2
+        #return obs, reward, done, info #ray1.9
         terminated = done #ray2.3
         truncated = False #ray2.3
         return obs, reward, terminated, truncated, info #ray2.3


### PR DESCRIPTION
I have made my changes to the reset and step functions according to https://gymnasium.farama.org/content/migration-guide/.

However, the error still remains and is as follows

`ray/rllib/evaluation/episode_v2.py", line 120, in policy_for
    policy_id = self._agent_to_policy[agent_id] = self.policy_mapping_fn(
TypeError: <lambda>() got an unexpected keyword argument 'worker'`

Probably, 

multiagent.py
        '"policy_mapping_fn": lambda x: "pol0" if x == 0 else "pol1", # # Function mapping agent ids to policy ids'

I think it has something to do with...

