### PR TITLE
fix: replace 2 bare except clauses with except Exception

### DIFF
--- a/gym_pybullet_drones/examples/beta.py
+++ b/gym_pybullet_drones/examples/beta.py
@@ -134,7 +134,7 @@ def run(
                                                     target_pos=target["pos"]+[INIT_XYZ[j][0], INIT_XYZ[j][1], 0],
                                                     target_vel=target["vel"]
                                                     )
-                except:
+                except Exception:
                     break
         
 

--- a/gym_pybullet_drones/examples/cf.py
+++ b/gym_pybullet_drones/examples/cf.py
@@ -95,7 +95,7 @@ def run(
                 yaw = i*np.pi/delta/2
                 rpy_rate = np.zeros(3)
                 env.sendFullStateCmd(pos, vel, acc, yaw, rpy_rate, t)
-            except:
+            except Exception:
                 break
 
         #### Log the simulation ####################################


### PR DESCRIPTION
Replaces 2 bare `except:` with `except Exception:` in `examples/cf.py` and `examples/beta.py`.